### PR TITLE
Changed OS X SDK from 'OS X 10.7' to 'Latest OS X'

### DIFF
--- a/src/devtools/base.xcconfig
+++ b/src/devtools/base.xcconfig
@@ -41,6 +41,6 @@ CLANG_CXX_LANGUAGE_STANDARD = gnu++11
 // gets into the header map, so sacrifice speed for corectness.
 USE_HEADERMAP = NO
 
-SDKROOT = macosx10.7
+SDKROOT = macosx
 MACOSX_DEPLOYMENT_TARGET = 10.5
 GCC_FAST_MATH = YES


### PR DESCRIPTION
Git converted the line endings, but the salient change is:

```
- SDKROOT = macosx10.7
+ SDKROOT = macosx
```

The OS X 10.7 SDK is not available in the latest versions of Xcode, and the only use of the OS X SDK is `osxfilebridge.mm`.

Without this change and without manually changing every generated Xcode target, every project fails to build in recent versions of Xcode.

See #1 point 2
